### PR TITLE
add relase-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,28 @@
+name-template: 'Meshery Adapter for [APP_NAME] v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'kind/feature'
+      - 'kind/enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'kind/fix'
+      - 'kind/bugfix'
+      - 'kind/bug'
+  - title: '🧰 Maintenance'
+    labels: 
+      - 'kind/chore'
+      - 'area/ci'
+      - 'area/tests'
+  - title: 📖 Documentation
+    label: area/docs 
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+template: |
+  ## What's New
+  $CHANGES
+  
+  ## Contributors
+  
+  Thank you to our contributors for making this release possible:
+  $CONTRIBUTORS

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is based on existing workflows.
As far as I can tell, it doesn't seem to be possible to use environment variables in the config, so we need to replace `[APP_NAME]` in `.github/release-drafter.yml` manually (`meshery-consul`: `[APP_NAME]` -> Consul).

Close #13 